### PR TITLE
Remove CENTER_CONSOLE_PORT_EXTERNAL environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,5 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install uv && uv pip install --system -r requirements.txt
 COPY . .
-ENV CENTER_CONSOLE_PORT_EXTERNAL=8501
-EXPOSE ${CENTER_CONSOLE_PORT_EXTERNAL}
-CMD ["sh", "-c", "streamlit run app.py --server.address=0.0.0.0 --server.port=${CENTER_CONSOLE_PORT_EXTERNAL} --server.fileWatcherType=none"]
+EXPOSE 8501
+CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0", "--server.port=8501", "--server.fileWatcherType=none"]

--- a/config.py
+++ b/config.py
@@ -11,7 +11,6 @@ class Config:
         self.rear_diff_port = os.getenv('REAR_DIFF_PORT_EXTERNAL')
         self.rear_diff_prefix = os.getenv('REAR_DIFF_PREFIX', 'rear-diff')
         self.api_timeout = int(os.getenv('CENTER_CONSOLE_API_TIMEOUT', '30'))
-        self.external_port = int(os.getenv('CENTER_CONSOLE_PORT_EXTERNAL', '8501'))
         
         self._validate_config()
         

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,12 @@ services:
     image: center-console:latest
     container_name: center-console
     ports:
-      - "${CENTER_CONSOLE_PORT_EXTERNAL:-8501}:${CENTER_CONSOLE_PORT_EXTERNAL:-8501}"
+      - "8501:8501"
     environment:
       - REAR_DIFF_HOST=192.168.50.2
       - REAR_DIFF_PORT_EXTERNAL=30812
       - REAR_DIFF_PREFIX=rear-diff
       - CENTER_CONSOLE_API_TIMEOUT=30
-      - CENTER_CONSOLE_PORT_EXTERNAL=${CENTER_CONSOLE_PORT_EXTERNAL:-8501}
     restart: unless-stopped
     networks:
       - app-network

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,6 @@ REAR_DIFF_HOST=192.168.50.2
 REAR_DIFF_PORT_EXTERNAL=30812
 REAR_DIFF_PREFIX=rear-diff
 CENTER_CONSOLE_API_TIMEOUT=30
-CENTER_CONSOLE_PORT_EXTERNAL=8501
 EOF
 
 # Run the application
@@ -90,7 +89,6 @@ docker run -d \
   -e REAR_DIFF_PORT_EXTERNAL=30812 \
   -e REAR_DIFF_PREFIX=rear-diff \
   -e CENTER_CONSOLE_API_TIMEOUT=30 \
-  -e CENTER_CONSOLE_PORT_EXTERNAL=8501 \
   center-console
 
 # View logs
@@ -116,7 +114,6 @@ For Kubernetes deployment on bare-metal clusters:
 - `REAR_DIFF_PORT_EXTERNAL`: API port number (e.g., `30812`)
 - `REAR_DIFF_PREFIX`: API base path without slashes (e.g., `rear-diff`)
 - `CENTER_CONSOLE_API_TIMEOUT`: Request timeout in seconds (default: 30)
-- `CENTER_CONSOLE_PORT_EXTERNAL`: External port for the Streamlit server (default: 8501)
 
 **Environment Management**
 - Local development: `.env` file with `python-dotenv`


### PR DESCRIPTION
Simplify port configuration by removing CENTER_CONSOLE_PORT_EXTERNAL variable and using fixed port 8501. Kubernetes will handle port mapping internally.

🤖 Generated with [Claude Code](https://claude.ai/code)